### PR TITLE
Prevent URL unescape of already escaped URLs.

### DIFF
--- a/src/HttpAdapter.php
+++ b/src/HttpAdapter.php
@@ -271,7 +271,6 @@ class HttpAdapter implements AdapterInterface
      */
     protected function buildUrl($path)
     {
-        $path = str_replace('%2F', '/', $path);
         $path = str_replace(' ', '%20', $path);
 
         return rtrim($this->base, '/') . '/' . $path;


### PR DESCRIPTION
Fixes #3 by not un-escaping already escaped slashes.